### PR TITLE
fix ms rounding for under 10s

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,11 @@
 
 **Site URL**: https://hitruns-top-times.vercel.app/
 
+## Site Setup
+- Install dependencies: `yarn`
+- Formatting: `yarn prettier`
+- Open static HTML files in browser for local development
+
 ### Site Origin / Purpose
 - This is a slimmed down version of Hitruns Records Discord Bot (https://github.com/solderq35/hitruns-records-bot). 
 - The Hitruns Top Times site only gets the top time for each category (rather than all runs like the Hiruns Records Discord Bot), and also splits up the requests by difficulty subcategory, so there is not as much lag when updating records; it is easier to keep this up to date than the Hitman Records Discord Bot.

--- a/src/index.js
+++ b/src/index.js
@@ -287,47 +287,41 @@ async function GenerateTable() {
           }
         } else {
           // console.log(initialTime)
-          if (initialTimeSeconds < 60 && initialTimeSeconds >= 10) {
-            finalTime = "0:" + initialTime;
-          } else if (initialTimeSeconds <= 9) {
-            finalTime = "0:0" + initialTime;
-          } else if (initialTimeSeconds >= 60) {
-            minutes = Math.floor(initialTime / 60);
-            seconds = Math.floor(initialTime % 60);
-            // milliseconds we multiply by 1000 and then take remainder after dividing by 1000, to eliminate
-            // float division rounding errors
-            let milliseconds = Math.floor((initialTime * 1000) % 1000);
+          minutes = Math.floor(initialTime / 60);
+          seconds = Math.floor(initialTime % 60);
+          // milliseconds we multiply by 1000 and then take remainder after dividing by 1000, to eliminate
+          // float division rounding errors
+          let milliseconds = Math.floor((initialTime * 1000) % 1000);
 
-            // put the minutes / seconds / milliseconds together formatted
-            let formatted_seconds;
-            let formatted_milliseconds;
+          // put the minutes / seconds / milliseconds together formatted
+          let formatted_seconds;
+          let formatted_milliseconds;
 
-            // add one leading zero to seconds digit if there are less than 10 seconds
-            if (seconds < 10) {
-              formatted_seconds = ":0" + Math.floor(seconds);
-            } else {
-              formatted_seconds = ":" + Math.floor(seconds);
-            }
-
-            // if there are no ms, then don't show anything
-            if (milliseconds === 0) {
-              formatted_milliseconds = "";
-            }
-
-            // add two leading zeros to milliseconds digit if there are less than 10 milliseconds
-            else if (milliseconds > 0 && milliseconds < 10) {
-              formatted_milliseconds = ".00" + (milliseconds % 1000);
-            }
-
-            // add one leading zero to milliseconds digit if there are 10 to 99 milliseconds
-            else if (milliseconds >= 10 && milliseconds < 100) {
-              formatted_milliseconds = ".0" + (milliseconds % 1000);
-            } else {
-              formatted_milliseconds = "." + (milliseconds % 1000);
-            }
-
-            finalTime = minutes + formatted_seconds + formatted_milliseconds;
+          // add one leading zero to seconds digit if there are less than 10 seconds
+          if (seconds < 10) {
+            formatted_seconds = ":0" + Math.floor(seconds);
+          } else {
+            formatted_seconds = ":" + Math.floor(seconds);
           }
+
+          // if there are no ms, then don't show anything
+          if (milliseconds === 0) {
+            formatted_milliseconds = "";
+          }
+
+          // add two leading zeros to milliseconds digit if there are less than 10 milliseconds
+          else if (milliseconds > 0 && milliseconds < 10) {
+            formatted_milliseconds = ".00" + (milliseconds % 1000);
+          }
+
+          // add one leading zero to milliseconds digit if there are 10 to 99 milliseconds
+          else if (milliseconds >= 10 && milliseconds < 100) {
+            formatted_milliseconds = ".0" + (milliseconds % 1000);
+          } else {
+            formatted_milliseconds = "." + (milliseconds % 1000);
+          }
+
+          finalTime = minutes + formatted_seconds + formatted_milliseconds;
         }
 
         // console.log(timearray)
@@ -479,47 +473,41 @@ async function GenerateTable() {
           }
         } else {
           // console.log(initialTime2)
-          if (initialTimeSeconds2 < 60 && initialTimeSeconds2 >= 10) {
-            finalTime2 = "0:" + initialTime2;
-          } else if (initialTimeSeconds2 <= 9) {
-            finalTime2 = "0:0" + initialTime2;
-          } else if (initialTimeSeconds2 >= 60) {
-            minutes = Math.floor(initialTime2 / 60);
-            seconds = Math.floor(initialTime2 % 60);
-            // milliseconds we multiply by 1000 and then take remainder after dividing by 1000, to eliminate
-            // float division rounding errors
-            let milliseconds = Math.floor((initialTime2 * 1000) % 1000);
+          minutes = Math.floor(initialTime2 / 60);
+          seconds = Math.floor(initialTime2 % 60);
+          // milliseconds we multiply by 1000 and then take remainder after dividing by 1000, to eliminate
+          // float division rounding errors
+          let milliseconds = Math.floor((initialTime2 * 1000) % 1000);
 
-            // put the minutes / seconds / milliseconds together formatted
-            let formatted_seconds;
-            let formatted_milliseconds;
+          // put the minutes / seconds / milliseconds together formatted
+          let formatted_seconds;
+          let formatted_milliseconds;
 
-            // add one leading zero to seconds digit if there are less than 10 seconds
-            if (seconds < 10) {
-              formatted_seconds = ":0" + Math.floor(seconds);
-            } else {
-              formatted_seconds = ":" + Math.floor(seconds);
-            }
-
-            // if there are no ms, then don't show anything
-            if (milliseconds === 0) {
-              formatted_milliseconds = "";
-            }
-
-            // add two leading zeros to milliseconds digit if there are less than 10 milliseconds
-            else if (milliseconds > 0 && milliseconds < 10) {
-              formatted_milliseconds = ".00" + (milliseconds % 1000);
-            }
-
-            // add one leading zero to milliseconds digit if there are 10 to 99 milliseconds
-            else if (milliseconds >= 10 && milliseconds < 100) {
-              formatted_milliseconds = ".0" + (milliseconds % 1000);
-            } else {
-              formatted_milliseconds = "." + (milliseconds % 1000);
-            }
-
-            finalTime2 = minutes + formatted_seconds + formatted_milliseconds;
+          // add one leading zero to seconds digit if there are less than 10 seconds
+          if (seconds < 10) {
+            formatted_seconds = ":0" + Math.floor(seconds);
+          } else {
+            formatted_seconds = ":" + Math.floor(seconds);
           }
+
+          // if there are no ms, then don't show anything
+          if (milliseconds === 0) {
+            formatted_milliseconds = "";
+          }
+
+          // add two leading zeros to milliseconds digit if there are less than 10 milliseconds
+          else if (milliseconds > 0 && milliseconds < 10) {
+            formatted_milliseconds = ".00" + (milliseconds % 1000);
+          }
+
+          // add one leading zero to milliseconds digit if there are 10 to 99 milliseconds
+          else if (milliseconds >= 10 && milliseconds < 100) {
+            formatted_milliseconds = ".0" + (milliseconds % 1000);
+          } else {
+            formatted_milliseconds = "." + (milliseconds % 1000);
+          }
+
+          finalTime2 = minutes + formatted_seconds + formatted_milliseconds;
         }
         // console.log(timearray2)
 


### PR DESCRIPTION
## Issue

![image](https://github.com/solderq35/hitruns-top-times/assets/82061589/5bd8292a-db7a-4ad4-ae9c-70678dd394ac)

Supposed to be 8.850

## Fix
- Just removed now extraneous if statements (no need to have separate control flow for under 10s runs, with new time formatting function)
- Also added local dev instructions to README (unrelated)